### PR TITLE
Refactors Layout so we keep DRY main views

### DIFF
--- a/src/renderer/components/common/layout/Layout.tsx
+++ b/src/renderer/components/common/layout/Layout.tsx
@@ -5,6 +5,7 @@ import { useBackgroundPosition } from '@/renderer/hooks/common/useBackgroundPosi
 
 import BackgroundImage from '../ui/BackgroundImage';
 import Breadcrumbs from './Breadcrumbs';
+import Main from './Main';
 
 export default function Layout() {
   const { position } = useBackgroundPosition();
@@ -13,9 +14,11 @@ export default function Layout() {
       <BackgroundImage position={position} />
       <div className='min-h-screen h-full relative overflow-hidden max-h-screen'>
         <Breadcrumbs />
-        <main className='mx-auto min-h-screen flex'>
-          <Outlet />
-        </main>
+        <div className='mx-auto min-h-screen flex'>
+          <Main>
+            <Outlet />
+          </Main>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/pages/characters/CreateCharacter.tsx
+++ b/src/renderer/pages/characters/CreateCharacter.tsx
@@ -11,24 +11,19 @@ export default function CreateCharacter() {
   const { onSubmit } = useCreateCharacter();
 
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <h1 className='text-2xl mb-4'>Create character</h1>
-        <Formik
-          initialValues={{
-            name: '',
-          }}
-          onSubmit={onSubmit}
-        >
-          <Form className='flex flex-col gap-2'>
-            <EntityFormField<Character>
-              propertyName='name'
-              placeholder='John'
-            />
-            <EntityFormSubmit />
-          </Form>
-        </Formik>
-      </div>
-    </Main>
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <h1 className='text-2xl mb-4'>Create character</h1>
+      <Formik
+        initialValues={{
+          name: '',
+        }}
+        onSubmit={onSubmit}
+      >
+        <Form className='flex flex-col gap-2'>
+          <EntityFormField<Character> propertyName='name' placeholder='John' />
+          <EntityFormSubmit />
+        </Form>
+      </Formik>
+    </div>
   );
 }

--- a/src/renderer/pages/characters/ReadCharacter.tsx
+++ b/src/renderer/pages/characters/ReadCharacter.tsx
@@ -74,200 +74,198 @@ export default function ReadCharacter() {
     });
   };
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <div>
-          <EntityTitle>Werewolf</EntityTitle>
-          <EntityGrid>
-            <EntityAttributeColumn>
-              {Object.keys(userDetails).map((key: keyof IDetails) => (
-                <EntityInputGroupText
-                  key={key}
-                  propertyName={key}
-                  propertyValue={userDetails[key]}
-                  update={handleUpdate}
-                />
-              ))}
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              <EntityInputSelect
-                list={Object.values(Breed)}
-                propertyName='breed'
-                propertyValue={wolfDetails.breed}
-                update={handleUpdate}
-              />
-              <EntityInputSelect
-                list={Object.values(Auspice)}
-                propertyName='auspice'
-                propertyValue={wolfDetails.auspice}
-                update={handleUpdate}
-              />
-              <EntityInputGroupText
-                propertyName='tribe'
-                propertyValue={wolfDetails.tribe}
-                update={handleUpdate}
-              />
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              {Object.keys(restDetails).map((key: keyof IDetails) => (
-                <EntityInputGroupText
-                  key={key}
-                  propertyName={key}
-                  propertyValue={userDetails[key]}
-                  update={handleUpdate}
-                />
-              ))}
-            </EntityAttributeColumn>
-          </EntityGrid>
-        </div>
-        <div>
-          <EntityTitle>Attributes</EntityTitle>
-          <EntityGrid>
-            <EntityAttributeColumn>
-              <p>Physical</p>
-              {Object.keys(physicalAttributes).map(
-                (key: keyof IPhysicalAttributes) => (
-                  <EntityInputGroupNumber
-                    key={key}
-                    propertyName={key}
-                    propertyValue={physicalAttributes[key]}
-                    update={handleUpdate}
-                  />
-                ),
-              )}
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              <p>Social</p>
-              {Object.keys(socialAttributes).map(
-                (key: keyof ISocialAttributes) => (
-                  <EntityInputGroupNumber
-                    key={key}
-                    propertyName={key}
-                    propertyValue={socialAttributes[key]}
-                    update={handleUpdate}
-                  />
-                ),
-              )}
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              <p>Mental</p>
-              {Object.keys(mentalAttributes).map(
-                (key: keyof IMentalAttributes) => (
-                  <EntityInputGroupNumber
-                    key={key}
-                    propertyName={key}
-                    propertyValue={mentalAttributes[key]}
-                    update={handleUpdate}
-                  />
-                ),
-              )}
-            </EntityAttributeColumn>
-          </EntityGrid>
-        </div>
-        <div>
-          <EntityTitle>Abilities:</EntityTitle>
-          <EntityGrid>
-            <EntityAttributeColumn>
-              <p>Talents</p>
-              {Object.keys(talents).map((key: keyof ITalents) => (
-                <EntityInputGroupNumber
-                  key={key}
-                  propertyName={key}
-                  propertyValue={talents[key]}
-                  update={handleUpdate}
-                />
-              ))}
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              <p>Skills</p>
-              {Object.keys(skills).map((key: keyof ISkills) => (
-                <EntityInputGroupNumber
-                  key={key}
-                  propertyName={key}
-                  propertyValue={skills[key]}
-                  update={handleUpdate}
-                />
-              ))}
-            </EntityAttributeColumn>
-            <EntityAttributeColumn>
-              <p>Knowledges</p>
-              {Object.keys(knowledges).map((key: keyof IKnowledges) => (
-                <EntityInputGroupNumber
-                  key={key}
-                  propertyName={key}
-                  propertyValue={knowledges[key]}
-                  update={handleUpdate}
-                />
-              ))}
-            </EntityAttributeColumn>
-          </EntityGrid>
-        </div>
-        <div>
-          <EntityTitle>Advantages</EntityTitle>
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <div>
+        <EntityTitle>Werewolf</EntityTitle>
+        <EntityGrid>
           <EntityAttributeColumn>
-            <p>Renown</p>
-            <EntityGrid columns={2}>
-              <EntityAttributeColumn>
-                {Object.keys(renown).map((key: keyof IRenown) => (
-                  <EntityInputGroupNumber
-                    key={key}
-                    maxDots={10}
-                    propertyName={key}
-                    propertyValue={renown[key]}
-                    update={handleUpdate}
-                  />
-                ))}
-              </EntityAttributeColumn>
-              <EntityAttributeColumn>
-                {Object.keys(self).map((key: keyof ISelf) => (
-                  <EntityInputGroupNumber
-                    key={key}
-                    maxDots={10}
-                    propertyName={key}
-                    propertyValue={self[key]}
-                    update={handleUpdate}
-                  />
-                ))}
-              </EntityAttributeColumn>
-            </EntityGrid>
+            {Object.keys(userDetails).map((key: keyof IDetails) => (
+              <EntityInputGroupText
+                key={key}
+                propertyName={key}
+                propertyValue={userDetails[key]}
+                update={handleUpdate}
+              />
+            ))}
           </EntityAttributeColumn>
-        </div>
+          <EntityAttributeColumn>
+            <EntityInputSelect
+              list={Object.values(Breed)}
+              propertyName='breed'
+              propertyValue={wolfDetails.breed}
+              update={handleUpdate}
+            />
+            <EntityInputSelect
+              list={Object.values(Auspice)}
+              propertyName='auspice'
+              propertyValue={wolfDetails.auspice}
+              update={handleUpdate}
+            />
+            <EntityInputGroupText
+              propertyName='tribe'
+              propertyValue={wolfDetails.tribe}
+              update={handleUpdate}
+            />
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            {Object.keys(restDetails).map((key: keyof IDetails) => (
+              <EntityInputGroupText
+                key={key}
+                propertyName={key}
+                propertyValue={userDetails[key]}
+                update={handleUpdate}
+              />
+            ))}
+          </EntityAttributeColumn>
+        </EntityGrid>
+      </div>
+      <div>
+        <EntityTitle>Attributes</EntityTitle>
+        <EntityGrid>
+          <EntityAttributeColumn>
+            <p>Physical</p>
+            {Object.keys(physicalAttributes).map(
+              (key: keyof IPhysicalAttributes) => (
+                <EntityInputGroupNumber
+                  key={key}
+                  propertyName={key}
+                  propertyValue={physicalAttributes[key]}
+                  update={handleUpdate}
+                />
+              ),
+            )}
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            <p>Social</p>
+            {Object.keys(socialAttributes).map(
+              (key: keyof ISocialAttributes) => (
+                <EntityInputGroupNumber
+                  key={key}
+                  propertyName={key}
+                  propertyValue={socialAttributes[key]}
+                  update={handleUpdate}
+                />
+              ),
+            )}
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            <p>Mental</p>
+            {Object.keys(mentalAttributes).map(
+              (key: keyof IMentalAttributes) => (
+                <EntityInputGroupNumber
+                  key={key}
+                  propertyName={key}
+                  propertyValue={mentalAttributes[key]}
+                  update={handleUpdate}
+                />
+              ),
+            )}
+          </EntityAttributeColumn>
+        </EntityGrid>
+      </div>
+      <div>
+        <EntityTitle>Abilities:</EntityTitle>
+        <EntityGrid>
+          <EntityAttributeColumn>
+            <p>Talents</p>
+            {Object.keys(talents).map((key: keyof ITalents) => (
+              <EntityInputGroupNumber
+                key={key}
+                propertyName={key}
+                propertyValue={talents[key]}
+                update={handleUpdate}
+              />
+            ))}
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            <p>Skills</p>
+            {Object.keys(skills).map((key: keyof ISkills) => (
+              <EntityInputGroupNumber
+                key={key}
+                propertyName={key}
+                propertyValue={skills[key]}
+                update={handleUpdate}
+              />
+            ))}
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            <p>Knowledges</p>
+            {Object.keys(knowledges).map((key: keyof IKnowledges) => (
+              <EntityInputGroupNumber
+                key={key}
+                propertyName={key}
+                propertyValue={knowledges[key]}
+                update={handleUpdate}
+              />
+            ))}
+          </EntityAttributeColumn>
+        </EntityGrid>
+      </div>
+      <div>
+        <EntityTitle>Advantages</EntityTitle>
         <EntityAttributeColumn>
-          <p>Backgrounds</p>
-          <CharacterBackgroundModal
-            backgrounds={advantages.backgrounds ?? []}
-            update={(e: Background[]) => handleUpdate('backgrounds', e)}
-          />
-        </EntityAttributeColumn>
-        <div>
+          <p>Renown</p>
           <EntityGrid columns={2}>
             <EntityAttributeColumn>
-              <p>Rituals</p>
-              <EntityModalList<Ritual>
-                allValues={rituals}
-                selectedValues={advantages.rites || []}
-                propertyName='rites'
-                update={handleUpdate}
-              />
+              {Object.keys(renown).map((key: keyof IRenown) => (
+                <EntityInputGroupNumber
+                  key={key}
+                  maxDots={10}
+                  propertyName={key}
+                  propertyValue={renown[key]}
+                  update={handleUpdate}
+                />
+              ))}
             </EntityAttributeColumn>
             <EntityAttributeColumn>
-              <p>Gifts</p>
-              <EntityModalList<Gift>
-                allValues={gifts}
-                selectedValues={advantages.gifts || []}
-                propertyName='gifts'
-                update={handleUpdate}
-              />
+              {Object.keys(self).map((key: keyof ISelf) => (
+                <EntityInputGroupNumber
+                  key={key}
+                  maxDots={10}
+                  propertyName={key}
+                  propertyValue={self[key]}
+                  update={handleUpdate}
+                />
+              ))}
             </EntityAttributeColumn>
           </EntityGrid>
-          <EntityDelete
-            entityName={CHARACTER_ENTITY_NAME}
-            showConfirmation={confirmDelete}
-            deleteEntity={deleteEntity}
-            cancelDelete={cancelDeleteEntity}
-          />
-        </div>
+        </EntityAttributeColumn>
       </div>
-    </Main>
+      <EntityAttributeColumn>
+        <p>Backgrounds</p>
+        <CharacterBackgroundModal
+          backgrounds={advantages.backgrounds ?? []}
+          update={(e: Background[]) => handleUpdate('backgrounds', e)}
+        />
+      </EntityAttributeColumn>
+      <div>
+        <EntityGrid columns={2}>
+          <EntityAttributeColumn>
+            <p>Rituals</p>
+            <EntityModalList<Ritual>
+              allValues={rituals}
+              selectedValues={advantages.rites || []}
+              propertyName='rites'
+              update={handleUpdate}
+            />
+          </EntityAttributeColumn>
+          <EntityAttributeColumn>
+            <p>Gifts</p>
+            <EntityModalList<Gift>
+              allValues={gifts}
+              selectedValues={advantages.gifts || []}
+              propertyName='gifts'
+              update={handleUpdate}
+            />
+          </EntityAttributeColumn>
+        </EntityGrid>
+        <EntityDelete
+          entityName={CHARACTER_ENTITY_NAME}
+          showConfirmation={confirmDelete}
+          deleteEntity={deleteEntity}
+          cancelDelete={cancelDeleteEntity}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/renderer/pages/gifts/CreateGift.tsx
+++ b/src/renderer/pages/gifts/CreateGift.tsx
@@ -11,25 +11,23 @@ export default function CreateGift() {
   const { onSubmit } = useCreateGift();
 
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <h1 className='text-2xl mb-4'>Create gift</h1>
-        <Formik
-          initialValues={{
-            name: '',
-          }}
-          onSubmit={onSubmit}
-        >
-          <Form className='flex flex-col gap-2'>
-            <EntityFormField<Gift>
-              propertyName='name'
-              placeholder='Blessing of the Moon'
-            />
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <h1 className='text-2xl mb-4'>Create gift</h1>
+      <Formik
+        initialValues={{
+          name: '',
+        }}
+        onSubmit={onSubmit}
+      >
+        <Form className='flex flex-col gap-2'>
+          <EntityFormField<Gift>
+            propertyName='name'
+            placeholder='Blessing of the Moon'
+          />
 
-            <EntityFormSubmit />
-          </Form>
-        </Formik>
-      </div>
-    </Main>
+          <EntityFormSubmit />
+        </Form>
+      </Formik>
+    </div>
   );
 }

--- a/src/renderer/pages/gifts/ReadGift.tsx
+++ b/src/renderer/pages/gifts/ReadGift.tsx
@@ -34,60 +34,58 @@ export default function ReadGift() {
     updateEntity({ [propertyName]: propertyValue });
   };
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <EntityTitle>{`Gift #${id}`}</EntityTitle>
-        <EntityInputGroupText
-          propertyName='name'
-          propertyValue={gift.name}
-          update={updateGift}
-        />
-        <EntityLevel
-          propertyName='level'
-          propertyValue={gift.level}
-          update={updateGift}
-        />
-        <EntityGrid columns={2}>
-          <EntityAttributeColumn>
-            <EntityTag>{capitalizeCamelCase('description')}</EntityTag>
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <EntityTitle>{`Gift #${id}`}</EntityTitle>
+      <EntityInputGroupText
+        propertyName='name'
+        propertyValue={gift.name}
+        update={updateGift}
+      />
+      <EntityLevel
+        propertyName='level'
+        propertyValue={gift.level}
+        update={updateGift}
+      />
+      <EntityGrid columns={2}>
+        <EntityAttributeColumn>
+          <EntityTag>{capitalizeCamelCase('description')}</EntityTag>
 
-            <EntityInputTextArea
-              propertyName='description'
-              propertyValue={gift.description}
-              update={updateGift}
-            />
-          </EntityAttributeColumn>
-          <EntityAttributeColumn>
-            <EntityTag>{capitalizeCamelCase('system')}</EntityTag>
-
-            <EntityInputTextArea
-              propertyName='system'
-              propertyValue={gift.system}
-              update={updateGift}
-            />
-          </EntityAttributeColumn>
-        </EntityGrid>
-        <EntityInputGroupText
-          propertyName='dataSource'
-          propertyValue={gift.dataSource}
-          update={updateGift}
-        />
-        <p>Gift Source</p>
-        <EntityGrid columns={2}>
-          <EntityModalList<GiftSource>
-            propertyName='giftSource'
-            selectedValues={gift.giftSource ?? []}
-            allValues={Object.values(GiftSource)}
+          <EntityInputTextArea
+            propertyName='description'
+            propertyValue={gift.description}
             update={updateGift}
           />
-        </EntityGrid>
-      </div>
+        </EntityAttributeColumn>
+        <EntityAttributeColumn>
+          <EntityTag>{capitalizeCamelCase('system')}</EntityTag>
+
+          <EntityInputTextArea
+            propertyName='system'
+            propertyValue={gift.system}
+            update={updateGift}
+          />
+        </EntityAttributeColumn>
+      </EntityGrid>
+      <EntityInputGroupText
+        propertyName='dataSource'
+        propertyValue={gift.dataSource}
+        update={updateGift}
+      />
+      <p>Gift Source</p>
+      <EntityGrid columns={2}>
+        <EntityModalList<GiftSource>
+          propertyName='giftSource'
+          selectedValues={gift.giftSource ?? []}
+          allValues={Object.values(GiftSource)}
+          update={updateGift}
+        />
+      </EntityGrid>
       <EntityDelete
         entityName={GIFT_ENTITY_NAME}
         showConfirmation={confirmDelete}
         deleteEntity={deleteEntity}
         cancelDelete={cancelDeleteEntity}
       />
-    </Main>
+    </div>
   );
 }

--- a/src/renderer/pages/rituals/CreateRitual.tsx
+++ b/src/renderer/pages/rituals/CreateRitual.tsx
@@ -11,25 +11,23 @@ export default function CreateRitual() {
   const { onSubmit } = useCreateRitual();
 
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <h1 className='text-2xl mb-4'>Create ritual</h1>
-        <Formik
-          initialValues={{
-            name: '',
-          }}
-          onSubmit={onSubmit}
-        >
-          <Form className='flex flex-col gap-2'>
-            <EntityFormField<Ritual>
-              propertyName='name'
-              placeholder='Rite of the Hunt'
-            />
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <h1 className='text-2xl mb-4'>Create ritual</h1>
+      <Formik
+        initialValues={{
+          name: '',
+        }}
+        onSubmit={onSubmit}
+      >
+        <Form className='flex flex-col gap-2'>
+          <EntityFormField<Ritual>
+            propertyName='name'
+            placeholder='Rite of the Hunt'
+          />
 
-            <EntityFormSubmit />
-          </Form>
-        </Formik>
-      </div>
-    </Main>
+          <EntityFormSubmit />
+        </Form>
+      </Formik>
+    </div>
   );
 }

--- a/src/renderer/pages/rituals/ReadRitual.tsx
+++ b/src/renderer/pages/rituals/ReadRitual.tsx
@@ -34,52 +34,50 @@ export default function ReadRitual() {
     updateEntity({ [propertyName]: propertyValue });
   };
   return (
-    <Main>
-      <div className='flex flex-col flex-1 w-full gap-8'>
-        <EntityTitle>{`Ritual #${id}`}</EntityTitle>
-        <EntityInputGroupText
-          propertyName='name'
-          propertyValue={ritual.name}
-          update={updateRitual}
-        />
-        <EntityLevel
-          propertyName='level'
-          propertyValue={ritual.level}
-          update={updateRitual}
-          type='number'
-          maxDots={10}
-        />
-        <EntityInputSelect
-          propertyName='type'
-          propertyValue={ritual.type}
-          list={Object.values(RitualType)}
-          update={updateRitual}
-        />
+    <div className='flex flex-col flex-1 w-full gap-8'>
+      <EntityTitle>{`Ritual #${id}`}</EntityTitle>
+      <EntityInputGroupText
+        propertyName='name'
+        propertyValue={ritual.name}
+        update={updateRitual}
+      />
+      <EntityLevel
+        propertyName='level'
+        propertyValue={ritual.level}
+        update={updateRitual}
+        type='number'
+        maxDots={10}
+      />
+      <EntityInputSelect
+        propertyName='type'
+        propertyValue={ritual.type}
+        list={Object.values(RitualType)}
+        update={updateRitual}
+      />
 
-        <EntityGrid columns={2}>
-          <EntityInputGroupTextArea
-            propertyName='description'
-            propertyValue={ritual.description}
-            update={updateRitual}
-          />
-          <EntityInputGroupTextArea
-            propertyName='system'
-            propertyValue={ritual.system}
-            update={updateRitual}
-          />
-        </EntityGrid>
-        <EntityInputGroupTextGroup
-          propertyName='dataSource'
-          propertyValue={ritual.dataSource}
+      <EntityGrid columns={2}>
+        <EntityInputGroupTextArea
+          propertyName='description'
+          propertyValue={ritual.description}
           update={updateRitual}
         />
-      </div>
+        <EntityInputGroupTextArea
+          propertyName='system'
+          propertyValue={ritual.system}
+          update={updateRitual}
+        />
+      </EntityGrid>
+      <EntityInputGroupTextGroup
+        propertyName='dataSource'
+        propertyValue={ritual.dataSource}
+        update={updateRitual}
+      />
       <EntityDelete
         entityName={RITUAL_ENTITY_NAME}
         showConfirmation={confirmDelete}
         deleteEntity={deleteEntity}
         cancelDelete={cancelDeleteEntity}
       />
-    </Main>
+    </div>
   );
 }


### PR DESCRIPTION
# Summary
This PR refactors the Layout component to eliminate the need for explicitly wrapping every page view with the <Main> component. By integrating <Main> directly into the Layout, all child components automatically inherit its structure, reducing redundancy and improving code maintainability.