### PR TITLE
Fix update by property name for number groups

### DIFF
--- a/src/renderer/components/character/CharacterForm.tsx
+++ b/src/renderer/components/character/CharacterForm.tsx
@@ -145,7 +145,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
             <EntitySubtitle>Physical</EntitySubtitle>
             {Object.keys(physicalAttributes).map(
               (key: keyof IPhysicalAttributes) => (
-                <EntityInputGroupNumber<Character>
+                <EntityInputGroupNumber
                   key={key}
                   propertyName={key}
                   propertyValue={physicalAttributes[key]}
@@ -157,7 +157,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
             <EntitySubtitle>Social</EntitySubtitle>
             {Object.keys(socialAttributes).map(
               (key: keyof ISocialAttributes) => (
-                <EntityInputGroupNumber<Character>
+                <EntityInputGroupNumber
                   key={key}
                   propertyName={key}
                   propertyValue={socialAttributes[key]}
@@ -169,7 +169,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
             <EntitySubtitle>Mental</EntitySubtitle>
             {Object.keys(mentalAttributes).map(
               (key: keyof IMentalAttributes) => (
-                <EntityInputGroupNumber<Character>
+                <EntityInputGroupNumber
                   key={key}
                   propertyName={key}
                   propertyValue={mentalAttributes[key]}
@@ -185,7 +185,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
           <EntityAttributeColumn>
             <EntitySubtitle>Talents</EntitySubtitle>
             {Object.keys(talents).map((key: keyof ITalents) => (
-              <EntityInputGroupNumber<Character>
+              <EntityInputGroupNumber
                 key={key}
                 propertyName={key}
                 propertyValue={talents[key]}
@@ -195,7 +195,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
           <EntityAttributeColumn>
             <EntitySubtitle>Skills</EntitySubtitle>
             {Object.keys(skills).map((key: keyof ISkills) => (
-              <EntityInputGroupNumber<Character>
+              <EntityInputGroupNumber
                 key={key}
                 propertyName={key}
                 propertyValue={skills[key]}
@@ -205,7 +205,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
           <EntityAttributeColumn>
             <EntitySubtitle>Knowledges</EntitySubtitle>
             {Object.keys(knowledges).map((key: keyof IKnowledges) => (
-              <EntityInputGroupNumber<Character>
+              <EntityInputGroupNumber
                 key={key}
                 propertyName={key}
                 propertyValue={knowledges[key]}
@@ -221,7 +221,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
             <EntityAttributeColumn>
               <EntitySubtitle>Renown</EntitySubtitle>
               {Object.keys(renown).map((key: keyof IRenown) => (
-                <EntityInputGroupNumber<Character>
+                <EntityInputGroupNumber
                   key={key}
                   maxDots={10}
                   propertyName={key}
@@ -232,7 +232,7 @@ export default function CharacterForm({ formTitle, update, character }: Props) {
             <EntityAttributeColumn>
               <EntitySubtitle>Self</EntitySubtitle>
               {Object.keys(self).map((key: keyof ISelf) => (
-                <EntityInputGroupNumber<Character>
+                <EntityInputGroupNumber
                   key={key}
                   maxDots={10}
                   propertyName={key}

--- a/src/renderer/components/common/entity/EntityInputGroupNumber.tsx
+++ b/src/renderer/components/common/entity/EntityInputGroupNumber.tsx
@@ -9,17 +9,18 @@ type Props = {
   propertyName: string;
   propertyValue: number;
   maxDots?: number;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 };
 
 export default function EntityInputGroupNumber({
   propertyName,
   propertyValue,
   maxDots = 5,
-  ...rest
+  onClick,
 }: Props) {
   return (
     <div
-      {...rest}
+      onClick={onClick}
       className='flex flex-col gap-2'
       data-testid={`entity-input-group-number-${propertyName}`}
     >

--- a/src/renderer/components/fight/FightForm.tsx
+++ b/src/renderer/components/fight/FightForm.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Character } from '@/main/modules/character/domain/character.entity';
 import { Fight } from '@/main/modules/fight/domain/fight.entity';
 import { useReadAllCharacters } from '@/renderer/hooks/character/useReadAllCharacters';
+import { useStats } from '@/renderer/hooks/common/useStats';
 
 import EntityAttributeColumn from '../common/entity/EntityAttributeColumn';
 import EntityGrid from '../common/entity/EntityGrid';
@@ -22,6 +23,7 @@ type Props = {
 };
 export default function FightForm({ formTitle, update, fight }: Props) {
   const { entities: characters } = useReadAllCharacters();
+  const { updateByPropertyName } = useStats(update);
   return (
     <div className='flex w-full flex-1 flex-col gap-8'>
       <EntityTitle>{formTitle}</EntityTitle>
@@ -37,6 +39,7 @@ export default function FightForm({ formTitle, update, fight }: Props) {
         update={(value: string) => update('description', value)}
       />
       <EntityInputGroupNumber
+        onClick={updateByPropertyName}
         propertyName='times'
         propertyValue={fight.times}
         maxDots={10}

--- a/src/renderer/components/gift/GiftForm.tsx
+++ b/src/renderer/components/gift/GiftForm.tsx
@@ -26,7 +26,7 @@ export default function GiftForm({ formTitle, update, gift }: Props) {
         propertyValue={gift.name}
         update={(e: string) => update('name', e)}
       />
-      <EntityInputGroupNumber<Gift>
+      <EntityInputGroupNumber
         onClick={updateByPropertyName}
         propertyName='level'
         propertyValue={gift.level}

--- a/src/renderer/components/ritual/RitualForm.tsx
+++ b/src/renderer/components/ritual/RitualForm.tsx
@@ -29,7 +29,7 @@ export default function RitualForm({ formTitle, update, ritual }: Props) {
         propertyValue={ritual.name}
         update={(value: string) => update('name', value)}
       />
-      <EntityInputGroupNumber<Ritual>
+      <EntityInputGroupNumber
         onClick={updateByPropertyName}
         propertyName='level'
         propertyValue={ritual.level}


### PR DESCRIPTION
# Summary
The update by property name was not working correctly on EntityInputGroupNumber. This PR fixes the issue by ensuring that the onClick handler is properly applied to the input group.