### PR TITLE
Fix/prod migration

### DIFF
--- a/resources/data/migrations/1742249720106-wta.js
+++ b/resources/data/migrations/1742249720106-wta.js
@@ -1,5 +1,3 @@
-const { MigrationInterface, QueryRunner } = require("typeorm");
-
 module.exports = class Wta1742249720106 {
     name = 'Wta1742249720106'
 

--- a/src/main/config/orm.config.ts
+++ b/src/main/config/orm.config.ts
@@ -30,7 +30,7 @@ const DEVELOPMENT: DataSourceOptions = {
 const PRODUCTION: DataSourceOptions = {
   type: 'sqlite',
   namingStrategy: new SnakeNamingStrategy(),
-  database: path.join(resourcesPath, 'wta.db'),
+  database: 'wta.db',
   synchronize: false,
   logging: false,
   subscribers: [],

--- a/src/main/config/orm.config.ts
+++ b/src/main/config/orm.config.ts
@@ -8,9 +8,9 @@ import { ENVIRONMENT } from './environment.enum';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-const dataPath = isDevelopment
-  ? 'resources/data'
-  : path.join(process.resourcesPath, 'resources', 'data');
+const resourcesPath = isDevelopment
+  ? 'resources'
+  : path.join(process.resourcesPath, 'resources');
 
 const testId = `test-${Date.now()}-${Math.random().toString(36).slice(0, 8)}.db`;
 const testPath = isDevelopment
@@ -30,12 +30,12 @@ const DEVELOPMENT: DataSourceOptions = {
 const PRODUCTION: DataSourceOptions = {
   type: 'sqlite',
   namingStrategy: new SnakeNamingStrategy(),
-  database: 'wta.db',
+  database: path.join(resourcesPath, 'wta.db'),
   synchronize: false,
-  logging: ['query'],
+  logging: false,
   subscribers: [],
   entities,
-  migrations: [path.join(dataPath, 'migrations/*.js')],
+  migrations: [path.join(resourcesPath, 'data', 'migrations/*.js')],
 };
 
 const TESTING: DataSourceOptions = {


### PR DESCRIPTION
# Summary
The generated migration files automatically adds an import typeorm statement at the top of migration files. However, since we are working with packaged applications, typeorm is not directly available. To make it work, I would have to manually update the import path, which is unnecessary since the import isn’t required for running the migration.

This PR removes the unnecessary import to simplify the process. Additionally, it includes a minor fix to database paths for better consistency.