### PR TITLE
Fix build workflow so that it triggers on tag pushing only and path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ env:
   app-name: wta-win32-x64
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 jobs:
@@ -26,8 +24,8 @@ jobs:
         run: npm run package:prod
       - name: Zip application
         run: |
-          cd out/{{ env.app-name }}
-          7z a ../../{{ env.app-name }}.zip .\*
+          cd out/$env:app-name
+          7z a ../../$env:app-name.zip .\*
       - uses: ncipollo/release-action@v1
         with:
           artifacts: '{{ env.app-name }}.zip'


### PR DESCRIPTION
# Summary
- Build workflow was supposed to trigger when pushing a new version change, however, it was triggering on every push to main. This change fixes that
- Build workflow was encountering an error due to YAML variables not being interpreted correctly when running commands on Windows. This fixes that